### PR TITLE
Grouper works with all combinations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,21 +36,21 @@ jobs:
 
     strategy:
       matrix:
-        Python36:
-          python.version: '3.6'
-          toxenv: 'py36'
-        Python37:
-          python.version: '3.7'
-          toxenv: 'py37'
-        Python38:
-          python.version: '3.8'
-          toxenv: 'py38'
         Python39:
           python.version: '3.9'
           toxenv: 'py39'
         Python310:
           python.version: '3.10'
           toxenv: 'py310'
+        Python311:
+          python.version: '3.11'
+          toxenv: 'py311'
+        Python312:
+          python.version: '3.12'
+          toxenv: 'py312'
+        Python313:
+          python.version: '3.13'
+          toxenv: 'py313'
         flake8:
           python.version: '3.9'
           toxenv: 'flake8'

--- a/pytest_azure_devops.py
+++ b/pytest_azure_devops.py
@@ -2,8 +2,6 @@
 
 import os
 import pytest
-from itertools import zip_longest
-from math import ceil
 
 
 def grouper(items, total_groups: int):

--- a/pytest_azure_devops.py
+++ b/pytest_azure_devops.py
@@ -31,6 +31,9 @@ def grouper(items, total_groups: int):
 
     >>> grouper([1,2,3,4,5,6,7,8], 8)
     [[1], [2], [3], [4], [5], [6], [7], [8]]
+
+    >>> grouper([1,2,3,4,5,6,7,8, 9], 4)
+    [[1, 2, 3], [4, 5], [6, 7], [8, 9]]
     """
     if total_groups <= 0:
         raise ValueError(f"total_groups should be bigger than zero but got {total_groups}")

--- a/pytest_azure_devops.py
+++ b/pytest_azure_devops.py
@@ -51,7 +51,7 @@ def grouper(items, total_groups: int):
         start += current_size
 
     return groups
-	
+
 
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(config, items):

--- a/pytest_azure_devops.py
+++ b/pytest_azure_devops.py
@@ -35,27 +35,14 @@ def grouper(items, total_groups: int):
     if total_groups <= 0:
         raise ValueError(f"total_groups should be bigger than zero but got {total_groups}")
 
-    if total_groups < (len(items) / 2):
-        chunk_size = ceil(len(items) / total_groups)
-    else:
-        chunk_size = 1
+    # Calculate the size of each group
+    group_size = len(lst) // n + (len(lst) % n != 0)
 
-    groups = [
-        [y for y in x if y] for x in zip_longest(*([iter(items)] * chunk_size), fillvalue=None)
-    ]
+    # Create the groups
+    groups = [lst[i:i + group_size] for i in range(0, len(lst), group_size)]
 
-    num_extra_groups = len(groups) - total_groups
-
-    if not num_extra_groups:
-        return groups
-    elif num_extra_groups > 0:
-        # rebalance extra groups
-        redist_groups = [groups[idx * 2] + groups[idx * 2 + 1] for idx in range(num_extra_groups)]
-        redist_groups += groups[num_extra_groups * 2:]
-        return redist_groups
-    else:
-        raise RuntimeError(f"Expected {total_groups} groups but got {groups}")
-
+    return groups
+	
 
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(config, items):

--- a/pytest_azure_devops.py
+++ b/pytest_azure_devops.py
@@ -34,12 +34,20 @@ def grouper(items, total_groups: int):
     """
     if total_groups <= 0:
         raise ValueError(f"total_groups should be bigger than zero but got {total_groups}")
+    if total_groups >= len(items):
+        return [[item] for item in items]
 
-    # Calculate the size of each group
-    group_size = len(lst) // n + (len(lst) % n != 0)
+    chunk_size = len(items) // total_groups
+    remainder = len(items) % total_groups
 
-    # Create the groups
-    groups = [lst[i:i + group_size] for i in range(0, len(lst), group_size)]
+    groups = []
+    start = 0
+
+    for i in range(total_groups):
+        # First 'remainder' groups get an extra item
+        current_size = chunk_size + (1 if i < remainder else 0)
+        groups.append(items[start:start + current_size])
+        start += current_size
 
     return groups
 	


### PR DESCRIPTION
The grouper algorithm failed with certain combinations ie. items [1, 2, 3, 4, 5, 6, 7, 8, 9] in 4 groups. This change will stop failing in case of such scenarios while implementing the same division strategy: subsequent items will be placed in the same group if possible: [1, 2, 3, 4, 5]  in two groups will end up in [1, 2, 3] and [4, 5].